### PR TITLE
Adding S3 signed upload

### DIFF
--- a/js/jquery.filer.js
+++ b/js/jquery.filer.js
@@ -477,7 +477,20 @@
 								formData.append(k, n.uploadFile.data[k])
 							}
 						}
-						f._ajax.send(el, formData, f._itFc);
+						if(n.uploadFile.S3 && n.uploadFile.signUrl){
+							var fileType = f._itFc.file.type.split('/');
+							$.post(n.uploadFile.signUrl, { filename: f._itFc.file.name, mimeType: fileType[0], mimeName: fileType[1] }, function (result) {
+									n.uploadFile.contentType = f._itFc.file.type;	
+									n.uploadFile.url = result.url;				 
+									f._ajax.send(el, formData, f._itFc);
+							}).fail(function () {
+								alert('error: signing failed');
+							});
+							
+							
+						}else {
+							f._ajax.send(el, formData, f._itFc);
+						}
 					},
 					_ajax: {
 						send: function(el, formData, c) {


### PR DESCRIPTION
2 options added to uploadFile ,
n.uploadFile.S3: true // support S3 upload
n.uploadFile.signUrl: '/api/s3/sign' // location to a post request to get the signed url to upload to

check this from AWS to implement the post request to sign url 
http://docs.aws.amazon.com/aws-sdk-php/v2/guide/service-s3.html#creating-a-pre-signed-url
